### PR TITLE
Update expected error message in TestInvalidHeight

### DIFF
--- a/health_index_app/Test_health_index_app/Models/Test_ApplicationUser.cs
+++ b/health_index_app/Test_health_index_app/Models/Test_ApplicationUser.cs
@@ -107,7 +107,7 @@ namespace Test_health_index_app.Models
             Assert.IsTrue(ValidateModel(applicationUser).Count == 1);
             Assert.IsTrue(ValidateModel(applicationUser).Any(
                     v => v.MemberNames.Contains("Height") &&
-                         v.ErrorMessage.Contains("Height must be in between 0 and less than 999.99")));
+                         v.ErrorMessage.Contains("Height must be in between 0 and 999.99")));
 
         }
 


### PR DESCRIPTION
A previous commit - 9f44b6c - updated the error message displayed to the user when the ApplicationUser object is assigned an invalid height. This commit updates the expected error message in TestInvalidHeight for when an ApplicationUser gives an invalid height.

This change fixes an issue that was causing the TestInvlidHeight test to fail. 